### PR TITLE
Update Google's DoH as per official announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ set which resolver mode you want.
 
 Publicly announced servers include:
 - https://mozilla.cloudflare-dns.com/dns-query
-- https://dns.google.com/experimental
+- https://dns.google/dns-query
 
 ## network.trr.credentials
 


### PR DESCRIPTION
https://security.googleblog.com/2019/06/google-public-dns-over-https-doh.html

@bagder 