### PR TITLE
README: Add network.trr.resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Entries are added to the TRR blacklist when the resolution fails with TRR but wo
 
 (default: `localhost,local`) Comma separated list of domain names to be resolved using the native resolver instead of TRR.
 
+## network.trr.resolvers
+
+(default: `[{ "name": "Cloudflare", "url": "https://mozilla.cloudflare-dns.com/dns-query" }]`) JSON list of DoH resolver providers that should be presented in the preferences GUI. Each item is an object with "name" and "url" keys. Modifying this should not be necessary unless you want to update the preferences GUI.
+
 # Split-horizon and blacklist
 
 With regular DNS, it is common to have clients in different places get different results back. This can be done since the servers know where the request are coming frome and they can then respond accordingly. When switching to another resolver with TRR, you may experience that you don’t always get the same set of addresses back. At times, this causes problems.


### PR DESCRIPTION
It is my understanding that this only affects the preferences GUI, let me know if that's not the case. (This setting was seen on firefox 68, haven't tried to find out when/how it was introduced.)

Besides this setting, I also see a `network.trr.custom_uri`, I assume this is also related to the preference GUI handling?

Thanks,